### PR TITLE
Add function for optional boolean query parameters

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -97,6 +97,26 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	return boolArray, nil
 }
 
+func parseQueryOptionalBool(r *http.Request, key string) (*bool, error) {
+	if exists := r.URL.Query().Has(key); exists {
+		var value bool
+		v := r.URL.Query().Get(key)
+		if v == "" {
+			value = true
+			return &value, nil
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, err})
+		} else {
+			value = b
+			return &value, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func parseQueryOptionalInt(r *http.Request, key string) (*int, error) {
 	s := r.URL.Query().Get(key)
 	if s == "" {

--- a/testdata/customarray/generated/api/api.go
+++ b/testdata/customarray/generated/api/api.go
@@ -97,6 +97,26 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	return boolArray, nil
 }
 
+func parseQueryOptionalBool(r *http.Request, key string) (*bool, error) {
+	if exists := r.URL.Query().Has(key); exists {
+		var value bool
+		v := r.URL.Query().Get(key)
+		if v == "" {
+			value = true
+			return &value, nil
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, err})
+		} else {
+			value = b
+			return &value, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func parseQueryOptionalInt(r *http.Request, key string) (*int, error) {
 	s := r.URL.Query().Get(key)
 	if s == "" {

--- a/testdata/formData/generated/api/api.go
+++ b/testdata/formData/generated/api/api.go
@@ -97,6 +97,26 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	return boolArray, nil
 }
 
+func parseQueryOptionalBool(r *http.Request, key string) (*bool, error) {
+	if exists := r.URL.Query().Has(key); exists {
+		var value bool
+		v := r.URL.Query().Get(key)
+		if v == "" {
+			value = true
+			return &value, nil
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, err})
+		} else {
+			value = b
+			return &value, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func parseQueryOptionalInt(r *http.Request, key string) (*int, error) {
 	s := r.URL.Query().Get(key)
 	if s == "" {

--- a/testdata/model/generated/api/api.go
+++ b/testdata/model/generated/api/api.go
@@ -97,6 +97,26 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	return boolArray, nil
 }
 
+func parseQueryOptionalBool(r *http.Request, key string) (*bool, error) {
+	if exists := r.URL.Query().Has(key); exists {
+		var value bool
+		v := r.URL.Query().Get(key)
+		if v == "" {
+			value = true
+			return &value, nil
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, err})
+		} else {
+			value = b
+			return &value, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func parseQueryOptionalInt(r *http.Request, key string) (*int, error) {
 	s := r.URL.Query().Get(key)
 	if s == "" {

--- a/testdata/simple/generated/api/api.go
+++ b/testdata/simple/generated/api/api.go
@@ -97,6 +97,26 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	return boolArray, nil
 }
 
+func parseQueryOptionalBool(r *http.Request, key string) (*bool, error) {
+	if exists := r.URL.Query().Has(key); exists {
+		var value bool
+		v := r.URL.Query().Get(key)
+		if v == "" {
+			value = true
+			return &value, nil
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, err})
+		} else {
+			value = b
+			return &value, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func parseQueryOptionalInt(r *http.Request, key string) (*int, error) {
 	s := r.URL.Query().Get(key)
 	if s == "" {


### PR DESCRIPTION
Consider the following scenario:

```
  /users:
    get:
      summary: "Get users but filter them according to some query parameters"
      operationId: "listUsers"
      parameters:
        - { name: "happy", in: "query", description: "Query for consultants", type: "boolean", allowEmptyValue: true, x-example: "", }
      responses:
        "200":
          description: "OK"
          schema: { type: array, items: { $ref: "#/definitions/UserResponse" } }
```

This should allow me to add a query string to my url, such as `?happy=true` or `happy=false`. However, as always with booleans, it makes sense to not make them required, but instead allow them to be just absent and interpreting this as `false` (somewhat).

Swagger-Go-Chi generates the above by using a function `parseQueryOptionalBool` which is simply missing in the set of functions. This PR adds this function by also paying attention to the two scenarios. So in short:

- `?happy` evaluates to "true"
- `?happy=true` evaluates to "true"
- `?happy=false` evaluates to "false"
- `?happy=somewhat` throws an error
-  (just omitted) evaluates to "nil" which can then be treated as false in the handler function

I didn't find any tests for these functions so for now I didn't test them ;) .