### PR TITLE
Use StatusBadRequest as error when parsing bodies

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -148,7 +148,7 @@ func parseBody(b []byte, i interface{}) error {
 }
 
 func JSONError(w http.ResponseWriter, err error) {
-	JSONErrorStatus(w, http.StatusInternalServerError, err)
+	JSONErrorStatus(w, http.StatusBadRequest, err)
 }
 
 func JSONErrorStatus(w http.ResponseWriter, status int, err error) {

--- a/testdata/customarray/generated/api/api.go
+++ b/testdata/customarray/generated/api/api.go
@@ -148,7 +148,7 @@ func parseBody(b []byte, i interface{}) error {
 }
 
 func JSONError(w http.ResponseWriter, err error) {
-	JSONErrorStatus(w, http.StatusInternalServerError, err)
+	JSONErrorStatus(w, http.StatusBadRequest, err)
 }
 
 func JSONErrorStatus(w http.ResponseWriter, status int, err error) {

--- a/testdata/formData/generated/api/api.go
+++ b/testdata/formData/generated/api/api.go
@@ -148,7 +148,7 @@ func parseBody(b []byte, i interface{}) error {
 }
 
 func JSONError(w http.ResponseWriter, err error) {
-	JSONErrorStatus(w, http.StatusInternalServerError, err)
+	JSONErrorStatus(w, http.StatusBadRequest, err)
 }
 
 func JSONErrorStatus(w http.ResponseWriter, status int, err error) {

--- a/testdata/model/generated/api/api.go
+++ b/testdata/model/generated/api/api.go
@@ -148,7 +148,7 @@ func parseBody(b []byte, i interface{}) error {
 }
 
 func JSONError(w http.ResponseWriter, err error) {
-	JSONErrorStatus(w, http.StatusInternalServerError, err)
+	JSONErrorStatus(w, http.StatusBadRequest, err)
 }
 
 func JSONErrorStatus(w http.ResponseWriter, status int, err error) {

--- a/testdata/simple/generated/api/api.go
+++ b/testdata/simple/generated/api/api.go
@@ -148,7 +148,7 @@ func parseBody(b []byte, i interface{}) error {
 }
 
 func JSONError(w http.ResponseWriter, err error) {
-	JSONErrorStatus(w, http.StatusInternalServerError, err)
+	JSONErrorStatus(w, http.StatusBadRequest, err)
 }
 
 func JSONErrorStatus(w http.ResponseWriter, status int, err error) {


### PR DESCRIPTION
We're still using your tool here ;) 

I believe that https://github.com/cugu/swagger-go-chi/blob/e5262671fc703c069b372be96a15c15f07a60afa/api/api.go#L151 is actually wrong and should be Bad Request.

In my view, if you forget to send the body or the body is wrongly formatted, that's not a 500 but a 400 as it's on you. Would you agree?