### PR TITLE
Fix possible resource exhaustion in API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -62,6 +62,9 @@ func parseQueryStringArray(r *http.Request, key string) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
+	}
 	return removeEmpty(stringArray), nil
 }
 
@@ -81,6 +84,9 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	stringArray, ok := r.URL.Query()[key]
 	if !ok {
 		return nil, nil
+	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
 	}
 	var boolArray []bool
 	for _, s := range stringArray {

--- a/testdata/customarray/generated/api/api.go
+++ b/testdata/customarray/generated/api/api.go
@@ -62,6 +62,9 @@ func parseQueryStringArray(r *http.Request, key string) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
+	}
 	return removeEmpty(stringArray), nil
 }
 
@@ -81,6 +84,9 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	stringArray, ok := r.URL.Query()[key]
 	if !ok {
 		return nil, nil
+	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
 	}
 	var boolArray []bool
 	for _, s := range stringArray {

--- a/testdata/formData/generated/api/api.go
+++ b/testdata/formData/generated/api/api.go
@@ -62,6 +62,9 @@ func parseQueryStringArray(r *http.Request, key string) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
+	}
 	return removeEmpty(stringArray), nil
 }
 
@@ -81,6 +84,9 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	stringArray, ok := r.URL.Query()[key]
 	if !ok {
 		return nil, nil
+	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
 	}
 	var boolArray []bool
 	for _, s := range stringArray {

--- a/testdata/model/generated/api/api.go
+++ b/testdata/model/generated/api/api.go
@@ -62,6 +62,9 @@ func parseQueryStringArray(r *http.Request, key string) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
+	}
 	return removeEmpty(stringArray), nil
 }
 
@@ -81,6 +84,9 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	stringArray, ok := r.URL.Query()[key]
 	if !ok {
 		return nil, nil
+	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
 	}
 	var boolArray []bool
 	for _, s := range stringArray {

--- a/testdata/simple/generated/api/api.go
+++ b/testdata/simple/generated/api/api.go
@@ -62,6 +62,9 @@ func parseQueryStringArray(r *http.Request, key string) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
+	}
 	return removeEmpty(stringArray), nil
 }
 
@@ -81,6 +84,9 @@ func parseQueryBoolArray(r *http.Request, key string) ([]bool, error) {
 	stringArray, ok := r.URL.Query()[key]
 	if !ok {
 		return nil, nil
+	}
+	if len(stringArray) > 1000 {
+		return nil, fmt.Errorf("%w", &HTTPError{http.StatusUnprocessableEntity, errors.New("too many items in query parameter")})
 	}
 	var boolArray []bool
 	for _, s := range stringArray {


### PR DESCRIPTION
The length of query parameters is not fixed. Most browsers tend to have an upper length, but attacks could come from everywhere. Checkmarx and similar tools recommend an upper limit.